### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup@v6
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,9 +16,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'


### PR DESCRIPTION
## Summary
- Update `actions/checkout` to v6
- Update `actions/setup-node` to v6
- Update `actions/setup-python` to v6 (where applicable)
- Update `github/codeql-action` to v4 (where applicable)

These updates resolve the Node.js 20 deprecation warnings. Node.js 20 actions will be forced to run with Node.js 24 starting June 2nd, 2026.

## Test plan
- [ ] CI passes on all matrix combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)